### PR TITLE
Write port to fd3

### DIFF
--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -113,7 +113,12 @@ export function startDebugServer(port: number, host?: string): Promise<IDisposab
       })
       .on('error', reject)
       .listen({ port, host }, () => {
-        console.log(`Debug server listening at ${(server.address() as net.AddressInfo).port}`);
+        // Instead of printing the port used to stdout,
+        // send it over FD 3.
+        const address = server.address() as net.AddressInfo;
+        const fd3 = fs.createWriteStream('', { fd: 3 });
+        fd3.write(`${address.port}`, () => fd3.close());
+
         resolve({
           dispose: () => {
             server.close();


### PR DESCRIPTION
## Why?

This is another modification made to the [vendored version of js-debug](https://github.com/replit/goval/tree/main/nix/dapNode). This writes the port number listened to by the DAP server, and writes it to file descriptor 3, which will be captured by debugproxy and utilized.

## Change

Added the change.

## Testing

Follow the testing procedure for https://github.com/replit/vscode-js-debug/pull/1 in a repl. Wire it up to the debugger in `.replit` and try a debugging session.